### PR TITLE
virtualNetworkName syntax error prevented azure cli deployment of tem…

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -658,7 +658,7 @@
 				"displayName": "OpenShiftNodeNetworkInterfaces"
 			},
 			"dependsOn": [
-				"[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
+				"[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
 			],
 			"copy": {
 				"name": "nodeNICLoop",


### PR DESCRIPTION
Due to a small syntax error, it was not possible to deploy a cluster using the azure cli as such:
azure group deployment create theResourceGroup -f ./azuredeploy.json

With the fix, it now works. Strangely enough, I did not hit this issue when clicking the 'Deploy to Azure' link, only via azure cli.